### PR TITLE
Added feature to fetch data from Hatways API instead of cached data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # blog-api
-This RESTful API was built as a solution for the Hatchways Backend assessment. It is built using Node.js and Express that will make an external request to fetch Blog data from an Hatchways API. If the blog data for a tag is there in the cache, it will fetch it from the cache. If not, it will make an API call to fetch the data and then cache the response. It will return an array of blog posts sorted by ID ascending by default.
+This RESTful API was built as a solution for the Hatchways Backend assessment. It is built using Node.js and Express that will make an external request to fetch Blog data from an Hatchways API. If the blog data for a tag is there in the cache, it will fetch it from the cache. If not, it will make an API call to fetch the data and then cache the response for 5 minutes. It will return an array of blog posts sorted by ID ascending by default.
 # Setup and run instructions:
 
 1. Install all dependencies using the following command:

--- a/controllers/getData.js
+++ b/controllers/getData.js
@@ -3,7 +3,7 @@ const sortByProperty = require("./sort.js");
 const cacheAPIData = require("./cacheAPIData.js");
 const retreiveCacheData = require("./retreiveCacheData.js");
 
-const axiosRequest = async (tags, sortBy, direction, noCache) => {
+const getData = async (tags, sortBy, direction, noCache) => {
     const postsObject = {};
     const postsArray = [];
     const unCachedTags = [];
@@ -48,4 +48,4 @@ const axiosRequest = async (tags, sortBy, direction, noCache) => {
     return sortedPosts;
 };
 
-module.exports = axiosRequest;
+module.exports = getData;

--- a/controllers/handleNoCache.js
+++ b/controllers/handleNoCache.js
@@ -1,0 +1,9 @@
+const handleNoCache = (noCache) => {
+    const noCacheAcceptedValues = ["yes", "no"];
+    const noCacheValue = noCache.toLowerCase().trim();
+    if(noCacheAcceptedValues.includes(noCacheValue)){
+        return noCacheValue === "yes";
+    }
+    return "invalid";
+};
+module.exports = handleNoCache;

--- a/controllers/request.js
+++ b/controllers/request.js
@@ -3,21 +3,28 @@ const sortByProperty = require("./sort.js");
 const cacheAPIData = require("./cacheAPIData.js");
 const retreiveCacheData = require("./retreiveCacheData.js");
 
-const axiosRequest = async (tags, sortBy, direction) => {
+const axiosRequest = async (tags, sortBy, direction, noCache) => {
     const postsObject = {};
     const postsArray = [];
     const unCachedTags = [];
-    for (let i=0; i<tags.length; i++) {
-        const tag = tags[i];
-        const cachedBlog = await retreiveCacheData(tag);
-        if(!cachedBlog){
+    if(noCache === false){
+        for (let i=0; i<tags.length; i++) {
+            const tag = tags[i];
+            const cachedBlog = await retreiveCacheData(tag);
+            if(!cachedBlog){
+                unCachedTags.push(tag);
+                continue;
+            }
+            const cachedBlogJson = JSON.parse(cachedBlog).posts;
+            for(let i=0; i<cachedBlogJson.length; i++){
+                postsObject[cachedBlogJson[i].id] = cachedBlogJson[i];
+            }
+        }
+    }
+    if(noCache === true){
+        await tags.forEach((tag) => {
             unCachedTags.push(tag);
-            continue;
-        }
-        const cachedBlogJson = JSON.parse(cachedBlog).posts;
-        for(let i=0; i<cachedBlogJson.length; i++){
-            postsObject[cachedBlogJson[i].id] = cachedBlogJson[i];
-        }
+        });
     }
     if(unCachedTags.length > 0){
         const urls = unCachedTags.map((tag) => {

--- a/routes/api/posts.js
+++ b/routes/api/posts.js
@@ -1,4 +1,4 @@
-const sendRequest = require("../../controllers/request.js");
+const getData = require("../../controllers/getData.js");
 const handleTags = require("../../controllers/handleTags.js");
 const handleDirection = require("../../controllers/handleDirection.js");
 const handleSortBy = require("../../controllers/handleSortBy.js");
@@ -17,14 +17,14 @@ const posts = async (req, res) => {
     console.log(limit);
     console.log(noCache);
     if(tags && sortBy !== "invalid" && direction !== "invalid" && limit !== null && limit !== "invalid" && noCache !== "invalid"){
-        const response = await sendRequest(tags, sortBy, direction, noCache);
+        const data = await getData(tags, sortBy, direction, noCache);
         try{
             res.status(200).json({
-                "posts": response.slice(0,limit)
+                "posts": data.slice(0,limit)
             });
         } catch {
             res.status(200).json({
-                "posts": response
+                "posts": data
             });
         }
     } else{

--- a/routes/api/posts.js
+++ b/routes/api/posts.js
@@ -3,18 +3,21 @@ const handleTags = require("../../controllers/handleTags.js");
 const handleDirection = require("../../controllers/handleDirection.js");
 const handleSortBy = require("../../controllers/handleSortBy.js");
 const handleLimit = require("../../controllers/handleLimit.js");
+const handleNoCache = require("../../controllers/handleNoCache.js");
 
 const posts = async (req, res) => {
     const tags = handleTags(req.query.tags);
     const sortBy = handleSortBy(req.query.sortBy);
     const direction = handleDirection(req.query.direction);
     const limit = handleLimit(req.query.limit);
+    const noCache = handleNoCache(req.query.noCache);
     console.log(tags);
     console.log(sortBy);
     console.log(direction);
     console.log(limit);
-    if(tags && sortBy !== "invalid" && direction !== "invalid" && limit !== null && limit !== "invalid"){
-        const response = await sendRequest(tags, sortBy, direction);
+    console.log(noCache);
+    if(tags && sortBy !== "invalid" && direction !== "invalid" && limit !== null && limit !== "invalid" && noCache !== "invalid"){
+        const response = await sendRequest(tags, sortBy, direction, noCache);
         try{
             res.status(200).json({
                 "posts": response.slice(0,limit)
@@ -48,6 +51,11 @@ const posts = async (req, res) => {
         if(limit === "invalid"){
             res.status(400).json({
                 "error": "limit parameter is invalid"
+            });
+        }
+        if(noCache === "invalid"){
+            res.status(400).json({
+                "error": "noCache parameter is invalid"
             });
         }
     }


### PR DESCRIPTION
If the user wants to fetch data directly from the API instead of the cached data, they can do so by passing in a query parameter noCache. This will fetch data from the Hatchways API as well as refresh the cache.